### PR TITLE
Don't depend on specific slf4j binding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
           <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-jdk14</artifactId>
+          <artifactId>slf4j-api</artifactId>
           <version>1.7.7</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
There is more than one slf4j output binding (simple (stderr), log4j12, jdk14, logback).
This explicit dependency on slf4j-jdk14 forces this binding to be dependency of projects that use stateless4j.
